### PR TITLE
Allow skip http wait

### DIFF
--- a/http/src/main/java/se/thinkcode/wait/HttpWaitMojo.java
+++ b/http/src/main/java/se/thinkcode/wait/HttpWaitMojo.java
@@ -26,7 +26,11 @@ public class HttpWaitMojo extends AbstractMojo {
     @Parameter
     Map<String, String> headers = Collections.emptyMap();
 
+    @Parameter(property = "http.wait.skip", defaultValue = "false")
+    boolean skip;
+
     public void execute() throws MojoExecutionException, MojoFailureException {
+        if (skip) return;
         getLog().info("Waiting for " + url);
         long startTime = System.currentTimeMillis();
 

--- a/http/src/test/java/se/thinkcode/wait/WaitTest.java
+++ b/http/src/test/java/se/thinkcode/wait/WaitTest.java
@@ -64,8 +64,16 @@ public class WaitTest {
         waitMojo.timeout = 10;
 
         assertThatExceptionOfType(TimeoutException.class).isThrownBy(
-                () -> waitMojo.execute()
+            () -> waitMojo.execute()
         ).withMessage("Connection to http://localhost:9090/geo/rest/v1/gata?gatunamn=drott timed out");
+    }
+
+    @Test
+    public void skip_wait() throws Exception {
+        waitMojo.url = "http://localhost";
+        waitMojo.skip = true;
+
+        waitMojo.execute();
     }
 
 }


### PR DESCRIPTION
Allow skip of the http wait plugin by adding -Dhttp.wait.skip to the
maven command or <skip>true</skip> to the configuration