### PR TITLE
Avoid infinite loop when con.getResponseCode() returns 404 immediately

### DIFF
--- a/http/src/main/java/se/thinkcode/wait/HttpWaitMojo.java
+++ b/http/src/main/java/se/thinkcode/wait/HttpWaitMojo.java
@@ -40,7 +40,7 @@ public class HttpWaitMojo extends AbstractMojo {
         int responseCode = HttpURLConnection.HTTP_NOT_FOUND;
         try {
             long endTime = System.currentTimeMillis() + timeout;
-            while (responseCode == HttpURLConnection.HTTP_NOT_FOUND) {
+            while (responseCode == HttpURLConnection.HTTP_NOT_FOUND && System.currentTimeMillis() < endTime) {
                 try {
                     URL obj = new URL(url);
                     HttpURLConnection con = (HttpURLConnection) obj.openConnection();


### PR DESCRIPTION
If con.getResponseCode() returns 404 immediately the loop would go on forever.