### PR TITLE
Add the specification of waitable statuses

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,17 @@ or by passing
 
 when running Maven.
 
+### Waitable Status Codes
+
+By default, this plugin waits as long as a `404` response status code is returned. You can configure additional status codes on which the plugin should wait via the `waitableStatuses` configurable element:
+
+    <waitableStatuses>
+        <waitableStatus>404</waitableStatus>
+        <waitableStatus>503</waitableStatus>
+    </waitableStatuses>
+
+This will not append to the default of waiting on `404` responses, so you will need to deliberately specify that here if you wish to continue waiting on such a response status code. 
+
 ## Release
 
 Instructions are available in [release.md](./release.md) and at [Sonatype](http://central.sonatype.org/pages/apache-maven.html)

--- a/http/src/test/java/se/thinkcode/wait/WaitTest.java
+++ b/http/src/test/java/se/thinkcode/wait/WaitTest.java
@@ -4,6 +4,7 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -25,6 +26,7 @@ public class WaitTest {
     @Before
     public void setUp() {
         waitMojo = new HttpWaitMojo();
+        waitMojo.waitableStatuses = Collections.singletonList(404);
     }
 
     @Test
@@ -77,5 +79,4 @@ public class WaitTest {
 
         waitMojo.execute();
     }
-
 }


### PR DESCRIPTION
I have a service that occasionally throws out HTTP 503 statuses while it's booting up. I don't want the plugin to fail on such a response, but continue waiting until the timeout.

This adds a configurable 'waitable statuses' option to the plugin that allows a consumer to specify a list of HTTP status codes that the plugin should wait on until the timeout is reached or an acceptable status is seen. It defaults to the previous behavior of only waiting on an HTTP 404 response.